### PR TITLE
Add getfrom within join operator

### DIFF
--- a/payload_translator/operators/join.py
+++ b/payload_translator/operators/join.py
@@ -1,5 +1,7 @@
 from .operator import Operator
 
+from .get_from import GetFrom
+
 
 class Join(Operator):
     """Operator to join values got from another operators. It join them into a
@@ -8,10 +10,10 @@ class Join(Operator):
     :param: delimiter: the delimiter character to put in the final string with
     the joined values
     """
-    def __init__(self, *operators, delimiter=' '):
-        self.operators = operators
+    def __init__(self, *fields, delimiter=' '):
+        self.fields = fields
         self.delimiter = delimiter
 
     def call(self, payload):
-        values = [str(operator.call(payload)) for operator in self.operators]
+        values = [str(GetFrom(field).call(payload)) for field in self.fields]
         return f'{self.delimiter}'.join(values)

--- a/payload_translator/operators/test_join.py
+++ b/payload_translator/operators/test_join.py
@@ -1,7 +1,5 @@
 from .join import Join
 
-from .get_from import GetFrom
-
 
 def test_join_fields_values():
     name = 'samuel'
@@ -18,9 +16,7 @@ def test_join_fields_values():
         }
     }
 
-    result = Join(GetFrom('name'),
-                  GetFrom('last_name'),
-                  GetFrom(('birthday', 'month')),
-                  GetFrom(('birthday', 'day'))).call(payload)
+    result = Join('name', 'last_name',
+                  ('birthday', 'month'), ('birthday', 'day')).call(payload)
 
     assert result == f'{name} {last_name} {month} {day}'

--- a/payload_translator/test_payload_translator.py
+++ b/payload_translator/test_payload_translator.py
@@ -59,8 +59,8 @@ def test_a_dict_translate():
         'my_favorite_movie': GetFrom('war_movie'),
         'my_second_favorite_movie': GetFrom('comedy_movie'),
         'my_third_favorite_movie': GetFrom(('dramas', 'romantic_drama')),
-        'my_movies_of_velocity': Join(GetFrom('car_movie'),
-                                      GetFrom('motorcycle_movie'),
+        'my_movies_of_velocity': Join('car_movie',
+                                      'motorcycle_movie',
                                       delimiter=', ')
     }
 


### PR DESCRIPTION
# Motivation
Improve the join operator as described in the issue https://github.com/samuel1992/payload-translator/issues/12

# What was made?
- Used the `GetFrom` operator within the `Join` code instead of pass it as parameter

